### PR TITLE
fix url decode

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -131,7 +131,7 @@ def parse_query_string(query_string):
             value = ""
         else:
             value = param[1]
-        query_params[key] = value
+        query_params[key] = unquote(value)
     return query_params
 
 


### PR DESCRIPTION
As you can see, whether it is the GET method or the POST method, the urlencode data should be unquoted.
This should not be done by developers manually calling the unquote function.